### PR TITLE
Facebook model guidelines - Click only filled views

### DIFF
--- a/sdk.adapter.facebook/src/main/java/net/pubnative/sdk/core/adapter/request/FacebookNativeAdModel.java
+++ b/sdk.adapter.facebook/src/main/java/net/pubnative/sdk/core/adapter/request/FacebookNativeAdModel.java
@@ -24,6 +24,7 @@
 package net.pubnative.sdk.core.adapter.request;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -38,11 +39,15 @@ import com.facebook.ads.NativeAd;
 
 import net.pubnative.sdk.core.request.PNAdModel;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class FacebookNativeAdModel extends PNAdModel implements AdListener {
 
     private static String TAG = FacebookNativeAdModel.class.getSimpleName();
     protected NativeAd  mNativeAd;
     protected MediaView mMediaView;
+    private boolean mTrackEntireLayout = true;
 
     public FacebookNativeAdModel(Context context, NativeAd nativeAd) {
         super(context);
@@ -156,10 +161,19 @@ public class FacebookNativeAdModel extends PNAdModel implements AdListener {
     // Tracking
     //----------------------------------------------------------------------------------------------
 
+    public PNAdModel trackEntireLayout(boolean trackEntireLayout) {
+        mTrackEntireLayout = trackEntireLayout;
+        return this;
+    }
+
     @Override
     public void startTracking(ViewGroup adView) {
         if (mNativeAd != null && adView != null) {
-            mNativeAd.registerViewForInteraction(adView);
+            if(mTrackEntireLayout) {
+                mNativeAd.registerViewForInteraction(adView);
+            } else {
+                mNativeAd.registerViewForInteraction(adView, prepareClickableViewList());
+            }
         }
     }
 
@@ -168,6 +182,33 @@ public class FacebookNativeAdModel extends PNAdModel implements AdListener {
         if (mNativeAd != null) {
             mNativeAd.unregisterView();
         }
+    }
+
+    @NonNull
+    private List<View> prepareClickableViewList() {
+        List<View> clickableViews = new ArrayList<>();
+        if (mBannerView != null) {
+            clickableViews.add(mBannerView);
+        }
+        if (mTitleView != null) {
+            clickableViews.add(mTitleView);
+        }
+        if (mDescriptionView != null) {
+            clickableViews.add(mDescriptionView);
+        }
+        if (mCallToActionView != null) {
+            clickableViews.add(mCallToActionView);
+        }
+        if (mIconView != null) {
+            clickableViews.add(mIconView);
+        }
+        if (mRatingView != null) {
+            clickableViews.add(mRatingView);
+        }
+        if (mContentInfoView != null) {
+            clickableViews.add(mContentInfoView);
+        }
+        return clickableViews;
     }
 
     //==============================================================================================

--- a/sdk.adapter.facebook/src/main/java/net/pubnative/sdk/core/adapter/request/FacebookNativeAdModel.java
+++ b/sdk.adapter.facebook/src/main/java/net/pubnative/sdk/core/adapter/request/FacebookNativeAdModel.java
@@ -45,7 +45,7 @@ import java.util.List;
 public class FacebookNativeAdModel extends PNAdModel implements AdListener {
 
     private static String TAG = FacebookNativeAdModel.class.getSimpleName();
-    protected NativeAd  mNativeAd;
+    protected NativeAd mNativeAd;
     protected MediaView mMediaView;
     private boolean mTrackEntireLayout = true;
 
@@ -103,7 +103,7 @@ public class FacebookNativeAdModel extends PNAdModel implements AdListener {
     @Override
     public View getBanner() {
 
-        if(mMediaView == null) {
+        if (mMediaView == null) {
             mMediaView = new MediaView(mContext);
             mMediaView.setNativeAd(mNativeAd);
         }
@@ -161,7 +161,7 @@ public class FacebookNativeAdModel extends PNAdModel implements AdListener {
     // Tracking
     //----------------------------------------------------------------------------------------------
 
-    public PNAdModel trackEntireLayout(boolean trackEntireLayout) {
+    public FacebookNativeAdModel trackEntireLayout(boolean trackEntireLayout) {
         mTrackEntireLayout = trackEntireLayout;
         return this;
     }
@@ -169,7 +169,7 @@ public class FacebookNativeAdModel extends PNAdModel implements AdListener {
     @Override
     public void startTracking(ViewGroup adView) {
         if (mNativeAd != null && adView != null) {
-            if(mTrackEntireLayout) {
+            if (mTrackEntireLayout) {
                 mNativeAd.registerViewForInteraction(adView);
             } else {
                 mNativeAd.registerViewForInteraction(adView, prepareClickableViewList());


### PR DESCRIPTION
Hello @cerberillo,
I am writing as part of ShopFully International Group android development team as we encountered an issue with the current FacebookNativeAdModel in the library.

We received feedback from facebook saying: _"Clickable white space - Only the ad titles, URLs, CTA, and image assets can be clickable (no clickable “white” space)”_

So in that case we require the use of _**com.facebook.ads.NativeAd.registerViewForInteraction(ViewGroup, List<View>)**_ which is not used at the moment.

In that pull request I added the required method to use the method and make clickable only the views that are filled by the model, not the background.

Have we missed any methods that permit us to do the same thing? Let us know!

Thank you